### PR TITLE
TYPO3 v7.6 LTS compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#PHPStorm/Webstorm
+.idea

--- a/onm_less/Classes/Utility/ParseLessPhp.php
+++ b/onm_less/Classes/Utility/ParseLessPhp.php
@@ -2,9 +2,6 @@
 namespace ONM\Less\Utility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-require_once( 'ParseLessAbstract.php' );
-
-
 /***************************************************************
  *  Copyright notice
  *

--- a/onm_less/Classes/Utility/ParseLessRecess.php
+++ b/onm_less/Classes/Utility/ParseLessRecess.php
@@ -2,9 +2,6 @@
 namespace ONM\Less\Utility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-require_once( 'ParseLessAbstract.php' );
-
-
 /***************************************************************
  *  Copyright notice
  *

--- a/onm_less/ext_emconf.php
+++ b/onm_less/ext_emconf.php
@@ -36,7 +36,7 @@ $EM_CONF[$_EXTKEY] = array (
 	array (
 		'depends' => 
 		array (
-			'typo3' => '6.0.0-6.2.99',
+			'typo3' => '6.0.0-7.6.99',
 		),
 		'conflicts' => '',
 		'suggests' => 


### PR DESCRIPTION
This PR just removed 2 superfluous require_once() statements and raises the TYPO3 compatibility level to version 7.6.99

I have tested the current version of onm_less with TYPO3 7.6 and could'nt find any major problems.
